### PR TITLE
Properly handle lagoon-core release naming in subcharts

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/templates/_helpers.tpl
+++ b/charts/lagoon-core/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "lagoon-core.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -12,15 +12,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "lagoon-core.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+{{- if contains .Chart.Name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 
@@ -341,4 +336,20 @@ Selector labels webhookHandler
 app.kubernetes.io/name: {{ include "lagoon-core.name" . }}
 app.kubernetes.io/component: {{ include "lagoon-core.webhookHandler.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+
+
+{{/*
+This template can be passed to subcharts that need the parent chart fullname.
+It is the same as the regular fullname template, but has a hard-coded
+.Chart.Name as this parent chart field is otherwise unavailable in subcharts.
+*/}}
+{{- define "lagoon-core.fullname.subchart" -}}
+{{- if contains "lagoon-core" .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name "lagoon-core" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -25,22 +25,20 @@
 rabbitMQUsername: lagoon
 
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
 
 # this is a chart dependency
 ssh:
   enabled: true
   apiDBHost: >-
-    {{ .Release.Name }}-api-db
+    {{ include "lagoon-core.fullname.subchart" . }}-api-db
   apiDBPasswordSecret: >-
-    {{ .Release.Name }}-api-db
+    {{ include "lagoon-core.fullname.subchart" . }}-api-db
   apiHost: >-
-    {{ .Release.Name }}-api
+    {{ include "lagoon-core.fullname.subchart" . }}-api
   authServer: >-
-    {{ .Release.Name }}-auth-server
+    {{ include "lagoon-core.fullname.subchart" . }}-auth-server
   jwtSecretSecret: >-
-    {{ .Release.Name }}-jwtsecret
+    {{ include "lagoon-core.fullname.subchart" . }}-jwtsecret
 
 api:
   replicaCount: 2


### PR DESCRIPTION
This allows subcharts to correctly determine the fullname of the parent chart.