### PR TITLE
Add ssh-portal to lagoon-core

### DIFF
--- a/charts/lagoon-core/Chart.yaml
+++ b/charts/lagoon-core/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/lagoon-core/README.md
+++ b/charts/lagoon-core/README.md
@@ -43,6 +43,7 @@ helm upgrade --install --create-namespace --namespace lagoon-core --values ./cha
 kubectl port-forward svc/lagoon-core-keycloak 8080 &
 kubectl port-forward svc/lagoon-core-api 7070:80 &
 kubectl port-forward svc/lagoon-core-ui 6060:3000 &
+kubectl port-forward svc/lagoon-core-ssh 2020 &
 ```
 
 Visit [http://localhost:6060/](http://localhost:6060/).

--- a/charts/lagoon-core/README.md
+++ b/charts/lagoon-core/README.md
@@ -29,9 +29,17 @@ webhookHandler:
   enabled: false
 webhooks2tasks:
   enabled: false
+sshPortal:
+  enabled: false
 ```
 
-## TL;DR Local testing
+## TL;DR Local testing using kind
+
+Prerequisite: download and install the [Lagoon CLI](https://github.com/amazeeio/lagoon-cli).
+
+NOTE: these instructions make use of the experimental `ssh-portal` service, which will eventually be moved to `lagoon-remote`. See [amazeeio/lagoon#2179](https://github.com/amazeeio/lagoon/pull/2179) for details.
+
+### Install
 
 Run these commands:
 
@@ -40,15 +48,44 @@ kind create cluster
 
 helm upgrade --install --create-namespace --namespace lagoon-core --values ./charts/lagoon-core/ci/linter-values.yaml --set lagoonAPIURL=http://localhost:7070/graphql --set keycloakAPIURL=http://localhost:8080/auth lagoon-core ./charts/lagoon-core
 
+# make a note of the lagoonadmin credentials
+
 kubectl port-forward svc/lagoon-core-keycloak 8080 &
 kubectl port-forward svc/lagoon-core-api 7070:80 &
 kubectl port-forward svc/lagoon-core-ui 6060:3000 &
 kubectl port-forward svc/lagoon-core-ssh 2020 &
+kubectl port-forward svc/lagoon-core-ssh-portal 2222 &
 ```
 
-Visit [http://localhost:6060/](http://localhost:6060/).
+### Use
 
-To uninstall:
+1. Visit [http://localhost:6060/](http://localhost:6060/).
+2. Log in using the `lagoonadmin` credentials from the helm chart installation.
+3. Click settings (top right).
+4. Add your ssh key.
+5. Add this config to `~/.lagoon.yml`:
+```
+current: local
+default: local
+lagoons:
+  local:
+    graphql: http://localhost:7070/graphql
+    hostname: localhost
+    port: 2222
+    ui: http://localhost:6060
+```
+6. Check you can log in:
+```
+$ lagoon whoami
+ID                                  	EMAIL	FIRSTNAME	LASTNAME	SSHKEYS 
+f57455c1-0d6b-491a-9117-89a9763dc940	-    	-        	-       	1	
+```
+
+At this point `lagoon-core` is installed.
+To actually deploy a project a `lagoon-remote` must be configured, which is beyond the scope of this README.
+
+### Uninstall
+
 ```
 helm uninstall lagoon-core
 # clean up the pvcs that kind doesn't reclaim automatically
@@ -57,7 +94,7 @@ kubectl delete pvc --all
 
 ## Quick Start
 
-Here is a minimal sensible `values.yaml`.
+Here is a super-minimal `values.yaml` for a real Lagoon installation.
 
 Important notes:
 
@@ -115,3 +152,4 @@ ssh:
 ## ServiceAccounts
 
 * The `broker` has a serviceaccount bound to a role to allow service discovery for HA clustering.
+* The `ssh-portal` (disabled by default, see [amazeeio/lagoon#2179](https://github.com/amazeeio/lagoon/pull/2179)) has a serviceaccount bound to a clusterrole to allow exec into pods.

--- a/charts/lagoon-core/ci/linter-values.yaml
+++ b/charts/lagoon-core/ci/linter-values.yaml
@@ -7,10 +7,54 @@ elasticsearchHost: logs.example.com
 lagoonAPIURL: https://api.example.com/graphql
 keycloakAPIURL: https://keycloak.example.com/auth
 
-# SSH subchart is currently enabled for CI.
-#
-# ssh:
-#   enabled: false
+# used in ssh-portal
+sshHostKeyRSA: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+  NhAAAAAwEAAQAAAYEA781JiRbdUmrAJm8Heze+jgODS7rF5+TxIWTB61R9G2sfppfDlIN5
+  C0iOG3ONIX1N0Vab+Ux3LXd12mlCiwDUofAJ0Hx7/CcCCa92TafTf3B9lBzmDIholxXTFN
+  +6fV/UlM/1exIhEFWBleZthFZEcYLur1XIfrtT7BqpFc62bOw7J2wqm35JxHxscLX630+G
+  OfEH9GarX3SI1sJ+AJpgVjs1iBmCiWAP+bbD204XWCtVyUmDTJISOlbvbv2cvq3BNYMRKk
+  Qk/U8dFG0onKGlwHj9lkRVxPJnnjcsUxVvuLrFxEEmK3BubkVUsPnhXivYFo7LMfL0eWQO
+  bFz715k9FaAl/DGXw5wDYmTTjzA3nn7rv5p/33tqgS35Tqq2FN0ROJlozpx9FZ5ytvCp2+
+  ZEtYydJznv84kRIzyOcfEN3QGh3dipTPI06CNJXoYH4Oia4qfsPWY3W54345opfiYCDexj
+  Wjy1QlXT55ijUGUuOfi5hxulbHo9VKNFypmpmrYbAAAFiIF6sdmBerHZAAAAB3NzaC1yc2
+  EAAAGBAO/NSYkW3VJqwCZvB3s3vo4Dg0u6xefk8SFkwetUfRtrH6aXw5SDeQtIjhtzjSF9
+  TdFWm/lMdy13ddppQosA1KHwCdB8e/wnAgmvdk2n039wfZQc5gyIaJcV0xTfun1f1JTP9X
+  sSIRBVgZXmbYRWRHGC7q9VyH67U+waqRXOtmzsOydsKpt+ScR8bHC1+t9PhjnxB/Rmq190
+  iNbCfgCaYFY7NYgZgolgD/m2w9tOF1grVclJg0ySEjpW7279nL6twTWDESpEJP1PHRRtKJ
+  yhpcB4/ZZEVcTyZ543LFMVb7i6xcRBJitwbm5FVLD54V4r2BaOyzHy9HlkDmxc+9eZPRWg
+  Jfwxl8OcA2Jk048wN55+67+af997aoEt+U6qthTdETiZaM6cfRWecrbwqdvmRLWMnSc57/
+  OJESM8jnHxDd0Bod3YqUzyNOgjSV6GB+DomuKn7D1mN1ueN+OaKX4mAg3sY1o8tUJV0+eY
+  o1BlLjn4uYcbpWx6PVSjRcqZqZq2GwAAAAMBAAEAAAGASULYcm9v0lwWtCc7i+Nt7gkYta
+  wsBjqliGQ18mVvi07g7o5zDA5WjqHt+GkG9vJHMetZ34IC7vsOIFoEIF9ylr604OMHJfPs
+  5XSbmgHp1YdSdkuV5MJP4cijIj9vxBng4k3eW2kgfNMCsf8h+ko4ws0TirGUfVNRwlIq0i
+  TDCufo8pRTOAoPE15H6u9N46dyBIWkvoAXXyRFIgdtY1XGlNGl+xyACuQ0PUAe+gMTkrY6
+  kTJKULxXoUcqAyisGH0QcJaadRt6Hk2OVMiaonHeYT/q4oBZek0PR5NmUGV+vmdanmnaZ5
+  6C7D8Nnjm1LSwEkrmc7TFZQOvGzhHILdINeg5tlb+DqgIXAxacPLmM7RKs0wG8Q00M1xeV
+  mPRtT6d8ysvUn3l6w84/AItB0ovtGfVmdxruES+B1h8fyht3NETeLM1OWJlPbJ2pVQNvqX
+  CQkrdtQBaeEliXcQ32fAL2htIWv9FLX3HJleHptcfnTn1v+0sbFIRWxgsXn+PZKHUBAAAA
+  wQCj5nRfybbX9RMWkASOT0wJ8t6lkINZDluv0TehN7hITMS9jfeGMtxB5FC0nks5Iv155N
+  YMjDRRNU32ZpLApAM+g6/WEU4JMsv/E1HeNnU31FI4n54oHvhTXVqovFglr+WylZy1RrjE
+  b8qs4ZvypSKzBpvPWJafxrOL3OjEMhaSrjuRYPU8dUKYXO3kzaa6I3WrvjQ7+/21RY985c
+  m1G9jSFmxiEfSva80EQztHQFhLW3Uj4wot6ClNyTI7n8ulybQAAADBAPs8+8ooTLa72mZ8
+  tSKAy2ImB0gROBJsPho+86fLB5dF9E9BW+2ceBWlyFHOnCXAultyeD/jd6Of2+yn2Jirmu
+  4ZHvGoZa5fuVzpW8UqF6H26kpqH4ohHuHQjnpwm/buY/izg7JfMnnlhvEviMlNs8mLjlhU
+  mSGkD1hRgsbDAOwfKap+EpHtlmciDkiPoft+R3NEAQgLaKYNqmQzkgjxOcrEZIEVKWnmu/
+  sV5Bs9x3ac8DmLu7Ko4CA0Ni6YSnXiwQAAAMEA9FjQdoK0bT57So4VYn5VTb/sEkTc93V+
+  otoMR2jMER1ZbPatC5FKHCVkqvkA9TNFOt2GIVBVCq/fAjgJcum0Tx0qH55gbN+aiDxxH5
+  cSHlemjcguJez5Tgp6mZchC72Ss86u4ZoQKP53VWnzMv+tJ5sSYby92PU03UrDIY/E/C+9
+  9wLJL1/b+sos2/Smh9hPdIEy8ZdIa0UXxPAzI8RPcCEYumqhsy+9H1QVXPloxzxnU+poNY
+  q+X3+iw1Dpj3vbAAAADHNjb3R0QHRoaW5reQECAwQFBg==
+  -----END OPENSSH PRIVATE KEY-----
+sshHostKeyED25519: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+  QyNTUxOQAAACCGR2030dqgzF7JRSAkQc1WYYtxcts+cAJowq0P0ogtiAAAAJBs3djPbN3Y
+  zwAAAAtzc2gtZWQyNTUxOQAAACCGR2030dqgzF7JRSAkQc1WYYtxcts+cAJowq0P0ogtiA
+  AAAEDPs553Igf3yEBMGZb39WTtxaIpGaje9Ow1kigBCrGocoZHbTfR2qDMXslFICRBzVZh
+  i3Fy2z5wAmjCrQ/SiC2IAAAADHNjb3R0QHRoaW5reQE=
+  -----END OPENSSH PRIVATE KEY-----
 
 api:
   replicaCount: 1
@@ -66,3 +110,8 @@ ssh:
   replicaCount: 1
   image:
     tag: lagoon-core
+
+sshPortal:
+  enabled: true
+  replicaCount: 1
+  debug: true

--- a/charts/lagoon-core/templates/NOTES.txt
+++ b/charts/lagoon-core/templates/NOTES.txt
@@ -25,7 +25,4 @@ The dashboard is available at:
   {{- end }}
 {{- end }}
 
-{{- $data := index (lookup "v1" "Secret" .Release.Namespace (include "lagoon-core.keycloak.fullname" .)) "data" | default dict }}
-{{- if $data }}
-Lagoon Admin credentials are: lagoonadmin / {{ index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | b64dec }}
-{{- end }}
+Lagoon Admin credentials are: lagoonadmin / {{ .Values.keycloakLagoonAdminPassword }}

--- a/charts/lagoon-core/templates/_helpers.tpl
+++ b/charts/lagoon-core/templates/_helpers.tpl
@@ -202,11 +202,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use for broker.
 */}}
 {{- define "lagoon-core.broker.serviceAccountName" -}}
-{{- if .Values.broker.serviceAccount.create }}
 {{- default (include "lagoon-core.broker.fullname" .) .Values.broker.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.broker.serviceAccount.name }}
-{{- end }}
 {{- end }}
 
 {{/*
@@ -654,6 +650,43 @@ Selector labels ssh.
 {{- define "lagoon-core.ssh.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "lagoon-core.name" . }}
 app.kubernetes.io/component: {{ include "lagoon-core.ssh.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+
+{{/*
+Create the name of the service account to use for ssh-portal.
+*/}}
+{{- define "lagoon-core.sshPortal.serviceAccountName" -}}
+{{- default (include "lagoon-core.sshPortal.fullname" .) .Values.sshPortal.serviceAccount.name }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for ssh-portal.
+*/}}
+{{- define "lagoon-core.sshPortal.fullname" -}}
+{{- include "lagoon-core.fullname" . }}-ssh-portal
+{{- end }}
+
+{{/*
+Common labels ssh-portal.
+*/}}
+{{- define "lagoon-core.sshPortal.labels" -}}
+helm.sh/chart: {{ include "lagoon-core.chart" . }}
+{{ include "lagoon-core.sshPortal.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels ssh-portal.
+*/}}
+{{- define "lagoon-core.sshPortal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lagoon-core.name" . }}
+app.kubernetes.io/component: {{ include "lagoon-core.sshPortal.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/lagoon-core/templates/auth-server.service.yaml
+++ b/charts/lagoon-core/templates/auth-server.service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
   - port: {{ .Values.authServer.service.port }}
     targetPort: http-3000
-    name: http-3000
+    name: http
   selector:
     {{- include "lagoon-core.authServer.selectorLabels" . | nindent 4 }}

--- a/charts/lagoon-core/templates/broker.serviceaccount.yaml
+++ b/charts/lagoon-core/templates/broker.serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.broker.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,4 +8,3 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}

--- a/charts/lagoon-core/templates/keycloak.secret.yaml
+++ b/charts/lagoon-core/templates/keycloak.secret.yaml
@@ -10,6 +10,8 @@ This somewhat complex logic is intended to:
 {{- $keycloakAPIClientSecret := coalesce .Values.keycloakAPIClientSecret (ternary uuidv4 (index $data "KEYCLOAK_API_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_API_CLIENT_SECRET" | empty)) }}
 {{- $keycloakAuthServerClientSecret := coalesce .Values.keycloakAuthServerClientSecret (ternary uuidv4 (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | default "" | b64dec) (index $data "KEYCLOAK_AUTH_SERVER_CLIENT_SECRET" | empty)) }}
 {{- $keycloakLagoonAdminPassword := coalesce .Values.keycloakLagoonAdminPassword (ternary (randAlpha 32) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | default "" | b64dec) (index $data "KEYCLOAK_LAGOON_ADMIN_PASSWORD" | empty)) }}
+{{/* set the variable globally for access in NOTES */}}
+{{- $_ := set .Values "keycloakLagoonAdminPassword" $keycloakLagoonAdminPassword -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/charts/lagoon-core/templates/ssh-portal.clusterrole.yaml
+++ b/charts/lagoon-core/templates/ssh-portal.clusterrole.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.sshPortal.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "lagoon-core.sshPortal.fullname" . }}-pod-exec
+  labels:
+    {{- include "lagoon-core.sshPortal.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-portal.clusterrolebinding.yaml
+++ b/charts/lagoon-core/templates/ssh-portal.clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.sshPortal.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "lagoon-core.sshPortal.fullname" . }}-pod-exec
+  labels:
+    {{- include "lagoon-core.sshPortal.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "lagoon-core.sshPortal.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "lagoon-core.sshPortal.fullname" . }}-pod-exec
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-portal.deployment.yaml
+++ b/charts/lagoon-core/templates/ssh-portal.deployment.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.sshPortal.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lagoon-core.sshPortal.fullname" . }}
+  labels:
+    {{- include "lagoon-core.sshPortal.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.sshPortal.autoscaling.enabled }}
+  replicas: {{ .Values.sshPortal.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "lagoon-core.sshPortal.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/ssh-portal.secret: {{ include (print $.Template.BasePath "/ssh-portal.secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "lagoon-core.sshPortal.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "lagoon-core.sshPortal.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.sshPortal.podSecurityContext | nindent 8 }}
+      containers:
+      - name: ssh
+        image: "{{ .Values.sshPortal.image.repository }}:{{ .Values.sshPortal.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.sshPortal.image.pullPolicy }}
+        command:
+        - "/ssh-portal"
+        {{- if .Values.sshPortal.debug }}
+        - "--debug"
+        {{- end }}
+        env:
+        - name: KEYCLOAK_BASEURL
+          value: http://{{ include "lagoon-core.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }}/
+        - name: KEYCLOAK_AUTH_SERVER_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.keycloak.fullname" . }}
+              key: KEYCLOAK_AUTH_SERVER_CLIENT_SECRET
+        - name: GRAPHQL_ENDPOINT
+          value: http://{{ include "lagoon-core.api.fullname" . }}:{{ .Values.api.service.port }}/graphql
+        - name: JWTSECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.fullname" . }}-jwtsecret
+              key: JWTSECRET
+        - name: HOSTKEY_RSA
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.sshPortal.fullname" . }}
+              key: HOSTKEY_RSA
+        - name: HOSTKEY_ED25519
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "lagoon-core.sshPortal.fullname" . }}
+              key: HOSTKEY_ED25519
+        ports:
+        - name: ssh
+          containerPort: 2222
+          protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: ssh
+        readinessProbe:
+          tcpSocket:
+            port: ssh
+        resources:
+          {{- toYaml .Values.ssh.resources | nindent 12 }}
+      {{- with .Values.ssh.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.name" . }}
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - {{ include "lagoon-core.sshPortal.fullname" . }}
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname
+      {{- with .Values.sshPortal.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sshPortal.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-portal.secret.yaml
+++ b/charts/lagoon-core/templates/ssh-portal.secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sshPortal.enabled -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "lagoon-core.sshPortal.fullname" . }}
+  labels:
+    {{- include "lagoon-core.sshPortal.labels" . | nindent 4 }}
+stringData:
+  HOSTKEY_RSA: |
+    {{- required "A valid .Values.sshHostKeyRSA is required!" .Values.sshHostKeyRSA | nindent 4 }}
+  HOSTKEY_ED25519: |
+    {{- required "A valid .Values.sshHostKeyED25519 is required!" .Values.sshHostKeyED25519 | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-portal.service.yaml
+++ b/charts/lagoon-core/templates/ssh-portal.service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.sshPortal.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lagoon-core.sshPortal.fullname" . }}
+  labels:
+    {{- include "lagoon-core.sshPortal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.sshPortal.service.type }}
+  ports:
+    - port: {{ .Values.sshPortal.service.port }}
+      targetPort: ssh
+      protocol: TCP
+      name: ssh
+  selector:
+    {{- include "lagoon-core.sshPortal.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lagoon-core/templates/ssh-portal.serviceaccount.yaml
+++ b/charts/lagoon-core/templates/ssh-portal.serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.sshPortal.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lagoon-core.sshPortal.serviceAccountName" . }}
+  labels:
+    {{- include "lagoon-core.sshPortal.labels" . | nindent 4 }}
+  {{- with .Values.sshPortal.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -213,7 +213,7 @@ authServer:
 
   service:
     type: ClusterIP
-    port: 3000
+    port: 80
 
   podAnnotations: {}
 

--- a/charts/lagoon-core/values.yaml
+++ b/charts/lagoon-core/values.yaml
@@ -11,6 +11,8 @@
 
 # lagoonAPIURL: https://api.example.com/graphql
 # keycloakAPIURL: https://keycloak.example.com/auth
+# sshHostKeyRSA: ...
+# sshHostKeyED25519: ...
 
 # These values are randomly generated on install if not otherwise defined:
 
@@ -187,8 +189,6 @@ broker:
   podAnnotations: {}
 
   serviceAccount:
-    # Specifies whether a service account should be created
-    create: true
     # Annotations to add to the service account
     annotations: {}
     # The name of the service account to use.
@@ -484,3 +484,31 @@ ssh:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
+
+sshPortal:
+  enabled: false
+  replicaCount: 2
+  image:
+    repository: amazeeiolagoon/ssh-portal
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "pr-2179"
+
+  service:
+    type: ClusterIP
+    port: 2222
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  serviceAccount:
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname
+    # template
+    name: ""


### PR DESCRIPTION
This PR adds ssh-portal support to the chart. See https://github.com/amazeeio/lagoon/pull/2179

It also adds fixes for the SSH service.

TODO:

* [x] configure minimal clusterrole and clusterrolebinding for ssh-portal