### PR TITLE
Add auth defaults for MongoDB providers

### DIFF
--- a/charts/dbaas-operator/Chart.yaml
+++ b/charts/dbaas-operator/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 
 appVersion: v0.1.6

--- a/charts/dbaas-operator/templates/mongodbprovider.yaml
+++ b/charts/dbaas-operator/templates/mongodbprovider.yaml
@@ -14,7 +14,7 @@ spec:
   user: {{ required (printf "user is required for %s" $providerName) $providerConfig.user | quote }}
   type: {{ $providerConfig.type | default "generic" | quote }}
   auth:
-    mechanism: {{ required (printf "auth.mechanism is required for %s" $providerName) $providerConfig.auth.mechanism | quote }}
-    source: {{ required (printf "auth.source is required for %s" $providerName) $providerConfig.auth.source | quote }}
-    tls: {{ required (printf "auth.tls (bool) is required for %s" $providerName) $providerConfig.auth.tls }}
+    mechanism: {{ required (printf "auth.mechanism is required for %s" $providerName) $providerConfig.auth.mechanism | default "SCRAM-SHA-1" | quote }}
+    source: {{ required (printf "auth.source is required for %s" $providerName) $providerConfig.auth.source | default "admin" | quote }}
+    tls: {{ required (printf "auth.tls (bool) is required for %s" $providerName) $providerConfig.auth.tls | default false }}
 {{- end }}

--- a/charts/dbaas-operator/templates/mongodbprovider.yaml
+++ b/charts/dbaas-operator/templates/mongodbprovider.yaml
@@ -14,7 +14,7 @@ spec:
   user: {{ required (printf "user is required for %s" $providerName) $providerConfig.user | quote }}
   type: {{ $providerConfig.type | default "generic" | quote }}
   auth:
-    mechanism: {{ required (printf "auth.mechanism is required for %s" $providerName) $providerConfig.auth.mechanism | default "SCRAM-SHA-1" | quote }}
-    source: {{ required (printf "auth.source is required for %s" $providerName) $providerConfig.auth.source | default "admin" | quote }}
-    tls: {{ required (printf "auth.tls (bool) is required for %s" $providerName) $providerConfig.auth.tls | default false }}
+    mechanism: {{ $providerConfig.auth.mechanism | default "SCRAM-SHA-1" | quote }}
+    source: {{ $providerConfig.auth.source | default "admin" | quote }}
+    tls: {{ $providerConfig.auth.tls | default false }}
 {{- end }}


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Adds the following auth defaults for MongoDB providers:
```
auth:
  mechanism: SCRAM-SHA-1
  source: admin
  tls: false
```