### PR TITLE
Bump dioscuri version

### DIFF
--- a/charts/dioscuri/Chart.yaml
+++ b/charts/dioscuri/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.2.1
+version: 0.2.2
 
-appVersion: v0.1.8
+appVersion: v0.1.9


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Bump to latest version of dioscuri