### PR TITLE
Toggle Dioscuri openshift support via chart

### DIFF
--- a/charts/dioscuri/Chart.yaml
+++ b/charts/dioscuri/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.2.2
+version: 0.3.0
 
 appVersion: v0.1.9

--- a/charts/dioscuri/templates/deployment.yaml
+++ b/charts/dioscuri/templates/deployment.yaml
@@ -43,9 +43,14 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /manager
-        {{- with .Values.extraArgs }}
+        {{- if or .Values.extraArgs .Values.global.openshift }}
         args:
+        {{- if .Values.global.openshift }}
+        - "--is-openshift=true"
+        {{- end }}
+        {{- with .Values.extraArgs }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/charts/dioscuri/values.yaml
+++ b/charts/dioscuri/values.yaml
@@ -1,7 +1,9 @@
 # the following values are defaults which may be overridden
 
-# If the controller is running in an openshift,
-# then the argument `--is-openshift=true` should be added
+global:
+  # set to true to enable openshift support
+  openshift: false
+
 extraArgs:
 - "--metrics-addr=127.0.0.1:8080"
 - "--enable-leader-election=true"


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

This PR makes it possible to toggle openshift support in dioscuri via a boolean chart value.

This is in support of https://github.com/uselagoon/lagoon-charts/pull/195
