### PR TITLE
Bump aergia to version with header support

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -61,7 +61,7 @@ jobs:
     - name: Run chart-testing (lint)
       run: ct lint --config ./default.ct.yaml
     - name: Create kind cluster
-      uses: helm/kind-action@v1.1.0
+      uses: helm/kind-action@v1.2.0
       if: steps.list-changed.outputs.changed == 'true'
     - name: Run chart-testing (install)
       run: ct install --config ./default.ct.yaml

--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -11,6 +11,6 @@ maintainers:
 
 type: application
 
-version: 0.1.4
+version: 0.1.5
 
-appVersion: v0.0.3
+appVersion: v0.0.4


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

