### PR TITLE
Add paused status support to fastly-controller chart and bump version

### DIFF
--- a/charts/fastly-controller/Chart.yaml
+++ b/charts/fastly-controller/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 
 type: application
 
-version: 0.1.1
+version: 0.2.0
 
-appVersion: v0.0.2
+appVersion: v0.1.0

--- a/charts/fastly-controller/templates/deployment.yaml
+++ b/charts/fastly-controller/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - name: CLUSTER_NAME
           value: {{ .Values.fastly.clusterName }}
         - name: ENABEL_PAUSED_STATUS_CRON
-          value: {{ .Values.enablePausedStatusCron }}
+          value: "{{ .Values.enablePausedStatusCron }}"
         - name: PAUSED_STATUS_CRON
           value: "{{ .Values.pausedStatusCron }}"
         command:

--- a/charts/fastly-controller/templates/deployment.yaml
+++ b/charts/fastly-controller/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - name: ENABEL_PAUSED_STATUS_CRON
           value: {{ .Values.enablePausedStatusCron }}
         - name: PAUSED_STATUS_CRON
-          value: {{ .Values.pausedStatusCron }}
+          value: "{{ .Values.pausedStatusCron }}"
         command:
         - /manager
         {{- with .Values.extraArgs }}

--- a/charts/fastly-controller/templates/deployment.yaml
+++ b/charts/fastly-controller/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
           value: {{ .Values.fastly.tlsConfigID }}
         - name: CLUSTER_NAME
           value: {{ .Values.fastly.clusterName }}
+        - name: ENABEL_PAUSED_STATUS_CRON
+          value: {{ .Values.enablePausedStatusCron }}
+        - name: PAUSED_STATUS_CRON
+          value: {{ .Values.pausedStatusCron }}
         command:
         - /manager
         {{- with .Values.extraArgs }}

--- a/charts/fastly-controller/values.yaml
+++ b/charts/fastly-controller/values.yaml
@@ -3,6 +3,9 @@ fastly:
   tlsConfigID: ""
   clusterName: ""
 
+enablePausedStatusCron: true
+pausedStatusCron: "*/5 * * * *"
+
 extraArgs:
 - "--metrics-addr=127.0.0.1:8080"
 - "--enable-leader-election=true"


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Add support to the fastly-controller chart to allow enabling or disabling of the paused status cron job, and adjusting its interval.