### PR TITLE
Templating fixes on the Aergia chart

### DIFF
--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -12,6 +12,6 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 
 appVersion: v0.1.2

--- a/charts/aergia/templates/deployment.yaml
+++ b/charts/aergia/templates/deployment.yaml
@@ -70,15 +70,15 @@ spec:
           env:
           {{- if .Values.idling }}{{- if or (eq .Values.idling.enableServiceIdler true) (eq .Values.idling.enableServiceIdler false) }}
           - name: ENABLE_SERVICE_IDLER
-            value: {{ .Values.idling.enableServiceIdler }}
+            value: {{ .Values.idling.enableServiceIdler | quote }}
           {{- end }}{{- end }}
           {{- if .Values.idling }}{{- if or (eq .Values.idling.enableCLIIdler true) (eq .Values.idling.enableCLIIdler false) }}
           - name: ENABLE_CLI_IDLER
-            value: {{ .Values.idling.enableCLIIdler }}
+            value: {{ .Values.idling.enableCLIIdler | quote }}
           {{- end }}{{- end }}
           {{- if .Values.idling }}{{- if or (eq .Values.idling.dryRun true) (eq .Values.idling.dryRun false) }}
           - name: DRY_RUN
-            value: {{ .Values.idling.dryRun }}
+            value: {{ .Values.idling.dryRun | quote }}
           {{- end }}{{- end }}
           {{- if .Values.templates.enabled}}
             - name: ERROR_FILES_PATH

--- a/charts/aergia/templates/deployment.yaml
+++ b/charts/aergia/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "aergia.labels" . | nindent 4 }}
 spec:
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "aergia.selectorLabels" . | nindent 6 }}

--- a/charts/aergia/values.yaml
+++ b/charts/aergia/values.yaml
@@ -16,6 +16,8 @@ serviceAccount:
   # If not set, a name is generated using the fullname template
   name: ""
 
+replicaCount: 1
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Explain the **details** for making this change. What existing problem does the pull request solve?

Hi,

I recently tried deploying the Aergia Helm chart on our cluster but ran into some templating issues:

1) The deployment resource definition template did not properly stringify booleans when templating pod environment variables.
2) The `replicaCount` parameter wasn't implemented so a HA deployment of the Aergia controller couldn't be created.

I've fixed up these two issues in this pull request and have tested the changes locally.

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
