### PR TITLE
chore: update to v0.3.3

### DIFF
--- a/charts/lagoon-idler/Chart.yaml
+++ b/charts/lagoon-idler/Chart.yaml
@@ -11,6 +11,6 @@ maintainers:
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 
-appVersion: v0.3.1
+appVersion: v0.3.3

--- a/charts/lagoon-idler/templates/clusterrole.yaml
+++ b/charts/lagoon-idler/templates/clusterrole.yaml
@@ -80,23 +80,6 @@ rules:
   - list
   - patch
   - watch
-- apiGroups:
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - build.openshift.io
-  resources:
-  - builds
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Once v0.3.3 of the idler is released, this chart needs to be released
