### PR TITLE
chore: bump controller to v0.3.0 with kubernetes 1.22.0+ support

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -61,7 +61,10 @@ jobs:
     - name: Run chart-testing (lint)
       run: ct lint --config ./default.ct.yaml
     - name: Create kind cluster
-      uses: helm/kind-action@v1.2.0
+      uses: helm/kind-action@v1.3.0
+      with:
+        version: v0.14.0
+        node_image: kindest/node:v1.23.6
       if: steps.list-changed.outputs.changed == 'true'
     - name: Run chart-testing (install)
       run: ct install --config ./default.ct.yaml

--- a/charts/fastly-controller/Chart.yaml
+++ b/charts/fastly-controller/Chart.yaml
@@ -13,8 +13,10 @@ maintainers:
   email: scott.leggett@amazee.io
   url: https://amazee.io
 
+kubeVersion: ">= 1.22.0-0"
+
 type: application
 
-version: 0.2.3
+version: 0.3.0
 
-appVersion: v0.2.1
+appVersion: v0.3.0


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Bump fastly-controller to v0.3.0 with support for kubernetes 1.22.0+ and set required kubernetes version to 1.22.0+
