### PR TITLE
fix: charts to support v0.3.1 fastly-controller

### DIFF
--- a/charts/fastly-controller/Chart.yaml
+++ b/charts/fastly-controller/Chart.yaml
@@ -17,6 +17,6 @@ kubeVersion: ">= 1.22.0-0"
 
 type: application
 
-version: 0.3.0
+version: 0.3.1
 
-appVersion: v0.3.0
+appVersion: v0.3.1

--- a/charts/fastly-controller/templates/role.yaml
+++ b/charts/fastly-controller/templates/role.yaml
@@ -7,8 +7,10 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - coordination.k8s.io
   resources:
   - configmaps
+  - leases
   verbs:
   - get
   - list


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Minor fixes and bump controller to v0.3.1
