### PR TITLE
chore: minor aergia idling template fixes

### DIFF
--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -12,6 +12,6 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.2.4
+version: 0.3.0
 
 appVersion: v0.1.2

--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -12,6 +12,6 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.2.3
+version: 0.2.4
 
 appVersion: v0.1.2

--- a/charts/aergia/templates/deployment.yaml
+++ b/charts/aergia/templates/deployment.yaml
@@ -47,40 +47,27 @@ spec:
           args:
             - "--metrics-addr=127.0.0.1:8080"
             - "--enable-leader-election=true"
-            {{- if .Values.idling }}{{- if .Values.idling.prometheusEndpoint }}
+            {{- if .Values.idling.enabled }}
             - "--prometheus-endpoint={{ .Values.idling.prometheusEndpoint }}"
-            {{- end }}{{- end }}
-            {{- if .Values.idling }}{{- if .Values.idling.prometheusCheckInterval }}
             - "--prometheus-interval={{ .Values.idling.prometheusCheckInterval }}"
-            {{- end }}{{- end }}
-            {{- if .Values.idling }}{{- if .Values.idling.podCheckInterval }}
             - "--pod-check-interval={{ .Values.idling.podCheckInterval }}"
-            {{- end }}{{- end }}
-            {{- if .Values.idling }}{{- if .Values.idling.cliCron }}
             - "--cli-idler-cron={{ .Values.idling.cliCron }}"
-            {{- end }}{{- end }}
-            {{- if .Values.idling }}{{- if .Values.idling.serviceCron }}
             - "--service-idler-cron={{ .Values.idling.serviceCron }}"
-            {{- end }}{{- end }}
-            {{- if .Values.idling }}{{- if .Values.idling.refreshInterval }}
             - "--refresh-interval={{ .Values.idling.refreshInterval }}"
-            {{- end }}{{- end }}
+            {{- end }}
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
-          {{- if .Values.idling }}{{- if or (eq .Values.idling.enableServiceIdler true) (eq .Values.idling.enableServiceIdler false) }}
+          {{- if .Values.idling.enabled }}
           - name: ENABLE_SERVICE_IDLER
             value: {{ .Values.idling.enableServiceIdler | quote }}
-          {{- end }}{{- end }}
-          {{- if .Values.idling }}{{- if or (eq .Values.idling.enableCLIIdler true) (eq .Values.idling.enableCLIIdler false) }}
           - name: ENABLE_CLI_IDLER
             value: {{ .Values.idling.enableCLIIdler | quote }}
-          {{- end }}{{- end }}
-          {{- if .Values.idling }}{{- if or (eq .Values.idling.dryRun true) (eq .Values.idling.dryRun false) }}
           - name: DRY_RUN
             value: {{ .Values.idling.dryRun | quote }}
-          {{- end }}{{- end }}
+          {{- else }}
+          {{- end }}
           {{- if .Values.templates.enabled}}
             - name: ERROR_FILES_PATH
               value: "/templates"

--- a/charts/aergia/values.yaml
+++ b/charts/aergia/values.yaml
@@ -75,17 +75,18 @@ templates:
     {{end}}
 
 idling:
-  # dryRun: false
-  # prometheusEndpoint: "http://monitoring-kube-prometheus-prometheus.monitoring.svc:9090"
-  # prometheusCheckInterval: "4h"
-  # podCheckInterval: 4
-  # enableCLIIdler: true
-  # enableServiceIdler: true
-  # cliCron: "5,35 * * * *"
-  # serviceCron: "0 */4 * * *"
-  # skipHitCheck: false
+  enabled: false
+  dryRun: false
+  prometheusEndpoint: "http://monitoring-kube-prometheus-prometheus.monitoring.svc:9090"
+  prometheusCheckInterval: "4h"
+  podCheckInterval: 4
+  enableCLIIdler: true
+  enableServiceIdler: true
+  cliCron: "5,35 * * * *"
+  serviceCron: "0 */4 * * *"
+  skipHitCheck: false
   # the length of time to display the loading page when unidling a namespace
-  # refreshInterval: 30
+  refreshInterval: 30
 
 customSelectors:
   enabled: false


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Minor changes to template for idling configuration, but this chart update disables idling by default
