### PR TITLE
chore: bump aergia to 0.3.2

### DIFF
--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -11,13 +11,11 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.5.1
+version: 0.5.2
 
-appVersion: v0.3.1
+appVersion: v0.3.2
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update aergia-controller appVersion to v0.3.1
-    - kind: changed
-      description: added metrics endpoint
+      description: update aergia-controller appVersion to v0.3.2


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Updates aergia chart to use v0.3.2 of the aergia controller