### PR TITLE
fix: subpath for files

### DIFF
--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.5.2
+version: 0.5.3
 
 appVersion: v0.3.2
 

--- a/charts/aergia/templates/deployment.yaml
+++ b/charts/aergia/templates/deployment.yaml
@@ -106,37 +106,44 @@ spec:
           {{- if .Values.unidling.ipAllowList}}
             - name: {{ include "aergia.fullname" . }}-allowedips
               mountPath: "/lists/allowedips"
+              subPath: "allowedips"
               readOnly: true
           {{- end}}
           {{- if .Values.unidling.ipBlockList}}
             - name: {{ include "aergia.fullname" . }}-blockedips
               mountPath: "/lists/blockedips"
+              subPath: "blockedips"
               readOnly: true
           {{- end}}
           {{- if .Values.unidling.agentAllowList}}
             - name: {{ include "aergia.fullname" . }}-allowedagents
               mountPath: "/lists/allowedagents"
+              subPath: "allowedagents"
               readOnly: true
           {{- end}}
           {{- if .Values.unidling.agentBlockList}}
             - name: {{ include "aergia.fullname" . }}-blockedagents
               mountPath: "/lists/blockedagents"
+              subPath: "blockedagents"
               readOnly: true
           {{- end}}
           {{- if .Values.templates.enabled}}
           {{- if .Values.templates.error}}
             - name: {{ include "aergia.fullname" . }}-error
               mountPath: "/templates/error.html"
+              subPath: "error.html"
               readOnly: true
           {{- end}}
           {{- if .Values.templates.forced}}
             - name: {{ include "aergia.fullname" . }}-forced
               mountPath: "/templates/forced.html"
+              subPath: "forced.html"
               readOnly: true
           {{- end}}
           {{- if .Values.templates.unidle}}
             - name: {{ include "aergia.fullname" . }}-unidle
               mountPath: "/templates/unidle.html"
+              subPath: "unidle.html"
               readOnly: true
           {{- end}}
           {{- end}}


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Just a fix for the files subpaths