### PR TITLE
chore: deprecate fastly-controller, lagoon-idler, and dioscuri charts

### DIFF
--- a/charts/dioscuri/Chart.yaml
+++ b/charts/dioscuri/Chart.yaml
@@ -5,17 +5,16 @@ description:
   (https://github.com/amazeeio/dioscuri).
 home: https://github.com/amazeeio/charts
 icon: https://raw.githubusercontent.com/amazeeio/charts/main/icon.png
-maintainers:
-- name: shreddedbacon
-  email: ben.jackson@amazee.io
-  url: https://amazee.io
-- name: smlx
-  email: scott.leggett@amazee.io
-  url: https://amazee.io
 kubeVersion: ">= 1.19.0-0"
+deprecated: true
 
 type: application
 
-version: 0.4.1
+version: 0.5.0
 
 appVersion: v0.2.0
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: deprecated chart

--- a/charts/fastly-controller/Chart.yaml
+++ b/charts/fastly-controller/Chart.yaml
@@ -5,18 +5,17 @@ description:
   (https://github.com/amazeeio/fastly-controller).
 home: https://github.com/amazeeio/charts
 icon: https://raw.githubusercontent.com/amazeeio/charts/main/icon.png
-maintainers:
-- name: shreddedbacon
-  email: ben.jackson@amazee.io
-  url: https://amazee.io
-- name: smlx
-  email: scott.leggett@amazee.io
-  url: https://amazee.io
+deprecated: true
 
 kubeVersion: ">= 1.22.0-0"
 
 type: application
 
-version: 0.3.1
+version: 0.4.0
 
 appVersion: v0.3.1
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: deprecated chart

--- a/charts/lagoon-idler/Chart.yaml
+++ b/charts/lagoon-idler/Chart.yaml
@@ -4,18 +4,15 @@ description:
   A Helm chart for Kubernetes which installs Lagoon Idler.
 home: https://github.com/amazeeio/charts
 icon: https://raw.githubusercontent.com/amazeeio/charts/main/icon.png
-maintainers:
-- name: shreddedbacon
-  email: ben.jackson@amazee.io
-  url: https://amazee.io
+deprecated: true
 
 type: application
 
-version: 0.1.2
+version: 0.2.0
 
 appVersion: v0.3.4
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update lagoon-idler appVersion to v0.3.4
+      description: deprecated chart


### PR DESCRIPTION
Announcing the deprecation of the following charts
* fastly-controller - no longer maintained/replaced with internal tooling for amazee.io
* lagoon-idler - use aergia instead
* dioscuri - no longer maintained, replaced with internal task function inside of Lagoon