### PR TITLE
chore: bump aergia controller version

### DIFF
--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -11,11 +11,11 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.5.3
+version: 0.6.0
 
-appVersion: v0.3.2
+appVersion: v0.4.1
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update aergia-controller appVersion to v0.3.2
+      description: update aergia-controller appVersion to v0.4.1

--- a/charts/aergia/values.yaml
+++ b/charts/aergia/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: amazeeio/aergia
+  repository: uselagoon/aergia
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Bump the version of aergia-controller to latest v0.4.1
