### PR TITLE
chore: bump aergia to v0.4.2

### DIFF
--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -11,11 +11,11 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.6.0
+version: 0.6.1
 
-appVersion: v0.4.1
+appVersion: v0.4.2
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update aergia-controller appVersion to v0.4.1
+      description: update aergia-controller appVersion to v0.4.2


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Bump aergia to include https://github.com/uselagoon/aergia-controller/pull/30
