### PR TITLE
chore: replace kubebuilder kube-rbac-proxy

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -68,3 +68,15 @@ jobs:
       if: steps.list-changed.outputs.changed == 'true'
     - name: Run chart-testing (install)
       run: ct install --config ./default.ct.yaml
+
+  linter-artifacthub:
+    runs-on: ubuntu-latest
+    container:
+      image: artifacthub/ah
+      options: --user root
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run ah lint
+        working-directory: ./charts/
+        run: ah lint

--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -11,11 +11,11 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.6.1
+version: 0.6.2
 
 appVersion: v0.4.2
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update aergia-controller appVersion to v0.4.2
+      description: interim use of bitnami/kube-rbac-proxy to replace deprecated kubebuilder version

--- a/charts/aergia/values.yaml
+++ b/charts/aergia/values.yaml
@@ -44,9 +44,9 @@ affinity: {}
 # this sidecar runs in the same pod as dbaas-operator
 kubeRBACProxy:
   image:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    repository: bitnami/kube-rbac-proxy
     pullPolicy: IfNotPresent
-    tag: v0.4.1
+    tag: 0.18.2
 
   securityContext: {}
 

--- a/charts/dbaas-operator/Chart.yaml
+++ b/charts/dbaas-operator/Chart.yaml
@@ -16,6 +16,6 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.3.0
+version: 0.3.1
 
 appVersion: v0.3.0

--- a/charts/dbaas-operator/values.yaml
+++ b/charts/dbaas-operator/values.yaml
@@ -117,9 +117,9 @@ affinity: {}
 # this sidecar runs in the same pod as dbaas-operator
 kubeRBACProxy:
   image:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    repository: bitnami/kube-rbac-proxy
     pullPolicy: IfNotPresent
-    tag: v0.4.1
+    tag: 0.18.2
 
   securityContext: {}
 

--- a/charts/principio/Chart.yaml
+++ b/charts/principio/Chart.yaml
@@ -11,6 +11,6 @@ maintainers:
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 
 appVersion: v0.2.0

--- a/charts/principio/values.yaml
+++ b/charts/principio/values.yaml
@@ -43,9 +43,9 @@ affinity: {}
 # this is a sidecar in the same pod as the principio container
 kubeRBACProxy:
   image:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    repository: bitnami/kube-rbac-proxy
     pullPolicy: IfNotPresent
-    tag: v0.4.1
+    tag: 0.18.2
 
   securityContext: {}
 


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Since kubebuilder announced the deprecation and removal of their `kube-rbac-proxy` image in #56 , this is an interim solution to use `bitnami/kube-rbac-proxy` instead.

The bitnami image while being a newer version of the kube-rbac-proxy, still functions the same way (with a few deprecation notices of flags). This will give us time to transition away from having to use it.

Some benefits to this are that this bitnami image is multi-arch.
