### PR TITLE
chore: remove kube-rbac-proxy

### DIFF
--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -11,11 +11,11 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.6.2
+version: 0.7.0
 
-appVersion: v0.4.2
+appVersion: v0.5.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: interim use of bitnami/kube-rbac-proxy to replace deprecated kubebuilder version
+      description: update aergia-controller to v0.5.0 and with removed kube-rbac-proxy

--- a/charts/aergia/templates/clusterrole.yaml
+++ b/charts/aergia/templates/clusterrole.yaml
@@ -81,6 +81,30 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - tokenreviews
+  verbs:
+  - "create"
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - "create"
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/aergia/templates/deployment.yaml
+++ b/charts/aergia/templates/deployment.yaml
@@ -22,21 +22,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: kube-rbac-proxy
-          securityContext:
-            {{- toYaml .Values.kubeRBACProxy.securityContext | nindent 12 }}
-          image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
-          imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
-          args:
-            - "--secure-listen-address=0.0.0.0:8443"
-            - "--upstream=http://127.0.0.1:8080/"
-            - "--logtostderr=true"
-            - "--v=10"
-          ports:
-            - containerPort: 8443
-              name: https
-          resources:
-            {{- toYaml .Values.kubeRBACProxy.resources | nindent 12 }}
         - name: manager
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -45,8 +30,8 @@ spec:
           command:
             - /manager
           args:
-            - "--metrics-addr=127.0.0.1:8080"
-            - "--enable-leader-election=true"
+            - "--metrics-bind-address=:8443"
+            - "--leader-elect=true"
             {{- if .Values.idling.enabled }}
             - "--prometheus-endpoint={{ .Values.idling.prometheusEndpoint }}"
             - "--prometheus-interval={{ .Values.idling.prometheusCheckInterval }}"
@@ -98,8 +83,8 @@ spec:
           ports:
             - containerPort: 5000
               name: backend
-            - containerPort: 9912
-              name: metrics
+            - containerPort: 8443
+              name: https
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/aergia/templates/role.yaml
+++ b/charts/aergia/templates/role.yaml
@@ -7,10 +7,8 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - coordination.k8s.io
   resources:
   - configmaps
-  - leases
   verbs:
   - get
   - list
@@ -20,13 +18,17 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ""
+  - coordination.k8s.io
   resources:
-  - configmaps/status
+  - leases
   verbs:
   - get
+  - list
+  - watch
+  - create
   - update
   - patch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/charts/aergia/templates/service.yaml
+++ b/charts/aergia/templates/service.yaml
@@ -30,21 +30,3 @@ spec:
       name: backend
   selector:
     {{- include "aergia.selectorLabels" . | nindent 4 }}
-{{- if .Values.metrics.enabled }}
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: {{ include "aergia.fullname" . }}-metrics
-  labels:
-    {{- include "aergia.labels" . | nindent 4 }}
-spec:
-  type: {{ .Values.backend.service.type }}
-  ports:
-    - name: metrics
-      protocol: TCP
-      port: 9912
-      targetPort: metrics
-  selector:
-    {{- include "aergia.selectorLabels" . | nindent 4 }}
-{{- end }}

--- a/charts/aergia/templates/servicemonitor.yaml
+++ b/charts/aergia/templates/servicemonitor.yaml
@@ -8,7 +8,12 @@ metadata:
 spec:
   endpoints:
     - interval: {{ .Values.metrics.interval }}
-      port: metrics
+      path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       {{- include "aergia.labels" . | nindent 6 }}

--- a/charts/aergia/values.yaml
+++ b/charts/aergia/values.yaml
@@ -41,17 +41,6 @@ tolerations: []
 
 affinity: {}
 
-# this sidecar runs in the same pod as dbaas-operator
-kubeRBACProxy:
-  image:
-    repository: bitnami/kube-rbac-proxy
-    pullPolicy: IfNotPresent
-    tag: 0.18.2
-
-  securityContext: {}
-
-  resources: {}
-
 templates:
   enabled: false
   error: |-


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Support for https://github.com/uselagoon/aergia-controller/pull/35. This removes the `kube-rbac-proxy` and updates the metrics endpoints and associated roles.