### PR TITLE
feat: support configurable response code in aergia

### DIFF
--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -11,11 +11,13 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.7.2
+version: 0.7.3
 
-appVersion: v0.5.2
+appVersion: v0.5.3
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update aergia-controller to v0.5.2
+      description: update aergia-controller to v0.5.3
+    - kind: changed
+      description: add support to change default response code

--- a/charts/aergia/templates/deployment.yaml
+++ b/charts/aergia/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - "--service-idler-cron={{ .Values.idling.serviceCron }}"
             - "--refresh-interval={{ .Values.idling.refreshInterval }}"
             {{- end }}
+            {{- with .Values.defaultHTTPResponseCode }}
+            - "--default-http-response-code={{ . }}"
+            {{- end }}
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/aergia/values.yaml
+++ b/charts/aergia/values.yaml
@@ -9,6 +9,9 @@ nameOverride: ""
 
 extraArgs:
 
+# This can be used to change the default http response code from the default 404
+# defaultHTTPResponseCode: 404
+
 serviceAccount:
   # Annotations to add to the service account
   annotations: {}


### PR DESCRIPTION
Update aergia to the latest v0.5.3 release and add support for configuring the default http response code in the template.