### PR TITLE
chore: bump dbaas-operator app version to v0.3.1

### DIFF
--- a/charts/dbaas-operator/Chart.yaml
+++ b/charts/dbaas-operator/Chart.yaml
@@ -16,6 +16,6 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.3.1
+version: 0.3.2
 
-appVersion: v0.3.0
+appVersion: v0.3.1


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Bump the dbaas-operator to v0.3.1