### PR TITLE
Update kube-rbac-proxy image

### DIFF
--- a/charts/dbaas-operator/Chart.yaml
+++ b/charts/dbaas-operator/Chart.yaml
@@ -16,6 +16,6 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.3.2
+version: 0.3.3
 
 appVersion: v0.3.1

--- a/charts/dbaas-operator/values.yaml
+++ b/charts/dbaas-operator/values.yaml
@@ -119,7 +119,7 @@ kubeRBACProxy:
   image:
     repository: quay.io/brancz/kube-rbac-proxy
     pullPolicy: IfNotPresent
-    tag: 0.18.2
+    tag: v0.18.2
 
   securityContext: {}
 

--- a/charts/dbaas-operator/values.yaml
+++ b/charts/dbaas-operator/values.yaml
@@ -117,7 +117,7 @@ affinity: {}
 # this sidecar runs in the same pod as dbaas-operator
 kubeRBACProxy:
   image:
-    repository: bitnami/kube-rbac-proxy
+    repository: quay.io/brancz/kube-rbac-proxy
     pullPolicy: IfNotPresent
     tag: 0.18.2
 


### PR DESCRIPTION
Related issue: https://amazeeio.atlassian.net/browse/PLAT-622

### Changes
- Replaced bitnami/kube-rbac-proxy image with `quay.io/brancz/kube-rbac-proxy`.
- Bumped dbaas-operator chart version.
