### PR TITLE
chore: update dbaas-operator to v0.4.0

### DIFF
--- a/charts/dbaas-operator/Chart.yaml
+++ b/charts/dbaas-operator/Chart.yaml
@@ -16,6 +16,11 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.3.3
+version: 0.4.0
 
-appVersion: v0.3.1
+appVersion: v0.4.0
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: update dbaas-operator to v0.4.0


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Update the dbaas-operator version to v0.4.0 and associated chart version.