### PR TITLE
chore: bump version of aergia to v0.5.4

### DIFF
--- a/charts/aergia/Chart.yaml
+++ b/charts/aergia/Chart.yaml
@@ -11,13 +11,11 @@ kubeVersion: ">= 1.23.0-0"
 
 type: application
 
-version: 0.7.3
+version: 0.7.4
 
-appVersion: v0.5.3
+appVersion: v0.5.4
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update aergia-controller to v0.5.3
-    - kind: changed
-      description: add support to change default response code
+      description: update aergia-controller to v0.5.4


### PR DESCRIPTION
Bump the version of aergia to v0.5.4