### PR TITLE
chore: update charts for dbaas-operator v0.5.0 changes

### DIFF
--- a/charts/dbaas-operator/Chart.yaml
+++ b/charts/dbaas-operator/Chart.yaml
@@ -16,11 +16,11 @@ kubeVersion: ">= 1.19.0-0"
 
 type: application
 
-version: 0.4.0
+version: 0.5.0
 
-appVersion: v0.4.0
+appVersion: v0.5.0
 
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: update dbaas-operator to v0.4.0
+      description: update dbaas-operator to v0.5.0

--- a/charts/dbaas-operator/templates/deployment.yaml
+++ b/charts/dbaas-operator/templates/deployment.yaml
@@ -21,21 +21,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-      - name: kube-rbac-proxy
-        securityContext:
-          {{- toYaml .Values.kubeRBACProxy.securityContext | nindent 10 }}
-        image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
-        imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=10"
-        ports:
-        - containerPort: 8443
-          name: https
-        resources:
-          {{- toYaml .Values.kubeRBACProxy.resources | nindent 10 }}
       - name: manager
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
@@ -44,10 +29,14 @@ spec:
         ports:
         - containerPort: 5000
           name: backend
+        - containerPort: 8443
+          name: https
         command:
         - /manager
-        {{- with .Values.extraArgs }}
         args:
+        - --metrics-bind-address=:8443
+        - --leader-elect=true
+        {{- with .Values.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if .Values.enableMariaDBProviders }}

--- a/charts/dbaas-operator/templates/role.yaml
+++ b/charts/dbaas-operator/templates/role.yaml
@@ -7,9 +7,19 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - coordination.k8s.io
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
   - leases
   verbs:
   - get
@@ -22,14 +32,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create
+  - patch

--- a/charts/dbaas-operator/values.yaml
+++ b/charts/dbaas-operator/values.yaml
@@ -71,8 +71,6 @@ mongodbProviders: {}
   #     tls: false
 
 extraArgs:
-- "--metrics-addr=127.0.0.1:8080"
-- "--enable-leader-election=true"
 
 # enable the providers
 # by default mariadb is enabled and the others are disabled
@@ -113,14 +111,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-# this sidecar runs in the same pod as dbaas-operator
-kubeRBACProxy:
-  image:
-    repository: quay.io/brancz/kube-rbac-proxy
-    pullPolicy: IfNotPresent
-    tag: v0.18.2
-
-  securityContext: {}
-
-  resources: {}


### PR DESCRIPTION
<!--
NOTE: Pull requests making changes to a chart must also bump the version of the
chart as per Semantic Versioning.

https://helm.sh/docs/topics/charts/#charts-and-versioning

In summary, given a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards compatible manner, and
- PATCH version when you make backwards compatible bug fixes.
-->

Updates the dbaas-operator chart to support changes in https://github.com/amazeeio/dbaas-operator/pull/72